### PR TITLE
Don't assume key events are numbers; they can be symbols.

### DIFF
--- a/xcb-keysyms.el
+++ b/xcb-keysyms.el
@@ -308,6 +308,7 @@ This function returns nil when it fails to convert an event."
           (push 'control event))
         (when (and (/= 0 (logand mask xcb:keysyms:shift-mask))
                    ;; Emacs only set shift bit for letters
+                   (integerp (car (last event)))
                    (<= ?A (car (last event))) (>= ?Z (car (last event))))
           (push 'shift event))
         (when (and xcb:keysyms:hyper-mask


### PR DESCRIPTION
```
    * xcb-keysyms.el (xcb:keysyms:keysym->event): Don't die when
translating events like shift-KP7.
```

Without this patch, hitting shift-KP7 (or any other function key) in line mode would crash EXWM.
