### PR TITLE
It's valid for WM_NORMAL_HINTS responses only to have 15 words.

### DIFF
--- a/xcb-icccm.el
+++ b/xcb-icccm.el
@@ -291,9 +291,8 @@ explicitly listed out."
          (slots (nthcdr (length slots-orig) slots))
          (value (slot-value obj 'value)))
     (unless value (setq value (make-vector (length slots) nil))) ;fallback
-    (cl-assert (= (length value) (length slots)))
     ;; Set explicit fields from value field
-    (dotimes (i (length slots))
+    (dotimes (i (length value))
       (setf (slot-value obj (cl--slot-descriptor-name (elt slots i)))
             (elt value i)))
     retval))


### PR DESCRIPTION
```
    * xcb-icccm.el (xcb:unmarshal): Accept short responses to the
WM_NORMAL_HINTS property, such as that provided by Xnest.
```

Without this patch, Xnest will crash EXWM upon being started.

I believe that in general, we need to be more careful about errors being generated when we parse client-provided data; it should never crash the window manager, just be ignored if it's invalid. Wrapping `xcb:unmarshal` calls in a `condition-case` macro might be sufficient to avoid that problem.

Anyway, I believe in this particular case, my documentation seems to suggest Xnest is doing the right (but outdated) thing by not responding with 18 words, only 15.
